### PR TITLE
Theme consistency

### DIFF
--- a/source/ui/instPage.cpp
+++ b/source/ui/instPage.cpp
@@ -9,11 +9,11 @@ namespace inst::ui {
     extern MainApplication *mainApp;
 
     instPage::instPage() : Layout::Layout() {
-        this->SetBackgroundColor(COLOR("#670000FF"));
+        this->SetBackgroundColor(COLOR("#343E87FF"));
         if (std::filesystem::exists(inst::config::appDir + "/background.png")) this->SetBackgroundImage(inst::config::appDir + "/background.png");
         else this->SetBackgroundImage("romfs:/images/background.jpg");
-        this->topRect = Rectangle::New(0, 0, 1280, 94, COLOR("#170909FF"));
-        this->infoRect = Rectangle::New(0, 95, 1280, 60, COLOR("#17090980"));
+        this->topRect = Rectangle::New(0, 0, 1280, 94, COLOR("#222D44FF"));
+        this->infoRect = Rectangle::New(0, 95, 1280, 60, COLOR("#222D4480"));
         this->titleImage = Image::New(0, 0, "romfs:/images/logo.png");
         this->appVersionText = TextBlock::New(480, 49, "v" + inst::config::appVersion, 22);
         this->appVersionText->SetColor(COLOR("#FFFFFFFF"));

--- a/source/ui/mainPage.cpp
+++ b/source/ui/mainPage.cpp
@@ -35,19 +35,19 @@ namespace inst::ui {
     }
 
     MainPage::MainPage() : Layout::Layout() {
-        this->SetBackgroundColor(COLOR("#670000FF"));
+        this->SetBackgroundColor(COLOR("#343E87FF"));
         if (std::filesystem::exists(inst::config::appDir + "/background.png")) this->SetBackgroundImage(inst::config::appDir + "/background.png");
         else this->SetBackgroundImage("romfs:/images/background.jpg");
-        this->topRect = Rectangle::New(0, 0, 1280, 94, COLOR("#170909FF"));
-        this->botRect = Rectangle::New(0, 659, 1280, 61, COLOR("#17090980"));
+        this->topRect = Rectangle::New(0, 0, 1280, 94, COLOR("#222D44FF"));
+        this->botRect = Rectangle::New(0, 659, 1280, 61, COLOR("#222D4480"));
         this->titleImage = Image::New(0, 0, "romfs:/images/logo.png");
         this->appVersionText = TextBlock::New(480, 49, "v" + inst::config::appVersion, 22);
         this->appVersionText->SetColor(COLOR("#FFFFFFFF"));
         this->butText = TextBlock::New(10, 678, "main.buttons"_lang, 24);
         this->butText->SetColor(COLOR("#FFFFFFFF"));
-        this->optionMenu = pu::ui::elm::Menu::New(0, 95, 1280, COLOR("#67000000"), 94, 6);
+        this->optionMenu = pu::ui::elm::Menu::New(0, 95, 1280, COLOR("#343E8700"), 94, 6);
         this->optionMenu->SetOnFocusColor(COLOR("#00000033"));
-        this->optionMenu->SetScrollbarColor(COLOR("#170909FF"));
+        this->optionMenu->SetScrollbarColor(COLOR("#222D44FF"));
         this->installMenuItem = pu::ui::elm::MenuItem::New("main.menu.sd"_lang);
         this->installMenuItem->SetColor(COLOR("#FFFFFFFF"));
         this->installMenuItem->SetIcon("romfs:/images/icons/micro-sd.png");

--- a/source/ui/netInstPage.cpp
+++ b/source/ui/netInstPage.cpp
@@ -19,12 +19,12 @@ namespace inst::ui {
     std::string sourceString = "";
 
     netInstPage::netInstPage() : Layout::Layout() {
-        this->SetBackgroundColor(COLOR("#670000FF"));
+        this->SetBackgroundColor(COLOR("#343E87FF"));
         if (std::filesystem::exists(inst::config::appDir + "/background.png")) this->SetBackgroundImage(inst::config::appDir + "/background.png");
         else this->SetBackgroundImage("romfs:/images/background.jpg");
-        this->topRect = Rectangle::New(0, 0, 1280, 94, COLOR("#170909FF"));
-        this->infoRect = Rectangle::New(0, 95, 1280, 60, COLOR("#17090980"));
-        this->botRect = Rectangle::New(0, 660, 1280, 60, COLOR("#17090980"));
+        this->topRect = Rectangle::New(0, 0, 1280, 94, COLOR("#222D44FF"));
+        this->infoRect = Rectangle::New(0, 95, 1280, 60, COLOR("#222D4480"));
+        this->botRect = Rectangle::New(0, 660, 1280, 60, COLOR("#222D4480"));
         this->titleImage = Image::New(0, 0, "romfs:/images/logo.png");
         this->appVersionText = TextBlock::New(480, 49, "v" + inst::config::appVersion, 22);
         this->appVersionText->SetColor(COLOR("#FFFFFFFF"));
@@ -34,7 +34,7 @@ namespace inst::ui {
         this->butText->SetColor(COLOR("#FFFFFFFF"));
         this->menu = pu::ui::elm::Menu::New(0, 156, 1280, COLOR("#FFFFFF00"), 84, (506 / 84));
         this->menu->SetOnFocusColor(COLOR("#00000033"));
-        this->menu->SetScrollbarColor(COLOR("#17090980"));
+        this->menu->SetScrollbarColor(COLOR("#222D4480"));
         this->infoImage = Image::New(453, 292, "romfs:/images/icons/lan-connection-waiting.png");
         this->Add(this->topRect);
         this->Add(this->infoRect);

--- a/source/ui/optionsPage.cpp
+++ b/source/ui/optionsPage.cpp
@@ -19,12 +19,12 @@ namespace inst::ui {
     std::vector<std::string> languageStrings = {"English", "日本語", "Français", "Deutsch", "Italiano", "Русский"};
 
     optionsPage::optionsPage() : Layout::Layout() {
-        this->SetBackgroundColor(COLOR("#670000FF"));
+        this->SetBackgroundColor(COLOR("#343E87FF"));
         if (std::filesystem::exists(inst::config::appDir + "/background.png")) this->SetBackgroundImage(inst::config::appDir + "/background.png");
         else this->SetBackgroundImage("romfs:/images/background.jpg");
-        this->topRect = Rectangle::New(0, 0, 1280, 94, COLOR("#170909FF"));
-        this->infoRect = Rectangle::New(0, 95, 1280, 60, COLOR("#17090980"));
-        this->botRect = Rectangle::New(0, 660, 1280, 60, COLOR("#17090980"));
+        this->topRect = Rectangle::New(0, 0, 1280, 94, COLOR("#222D44FF"));
+        this->infoRect = Rectangle::New(0, 95, 1280, 60, COLOR("#222D4480"));
+        this->botRect = Rectangle::New(0, 660, 1280, 60, COLOR("#222D4480"));
         this->titleImage = Image::New(0, 0, "romfs:/images/logo.png");
         this->appVersionText = TextBlock::New(480, 49, "v" + inst::config::appVersion, 22);
         this->appVersionText->SetColor(COLOR("#FFFFFFFF"));
@@ -34,7 +34,7 @@ namespace inst::ui {
         this->butText->SetColor(COLOR("#FFFFFFFF"));
         this->menu = pu::ui::elm::Menu::New(0, 156, 1280, COLOR("#FFFFFF00"), 84, (506 / 84));
         this->menu->SetOnFocusColor(COLOR("#00000033"));
-        this->menu->SetScrollbarColor(COLOR("#17090980"));
+        this->menu->SetScrollbarColor(COLOR("#222D4480"));
         this->Add(this->topRect);
         this->Add(this->infoRect);
         this->Add(this->botRect);

--- a/source/ui/sdInstPage.cpp
+++ b/source/ui/sdInstPage.cpp
@@ -13,12 +13,12 @@ namespace inst::ui {
     extern MainApplication *mainApp;
 
     sdInstPage::sdInstPage() : Layout::Layout() {
-        this->SetBackgroundColor(COLOR("#670000FF"));
+        this->SetBackgroundColor(COLOR("#343E87FF"));
         if (std::filesystem::exists(inst::config::appDir + "/background.png")) this->SetBackgroundImage(inst::config::appDir + "/background.png");
         else this->SetBackgroundImage("romfs:/images/background.jpg");
-        this->topRect = Rectangle::New(0, 0, 1280, 94, COLOR("#170909FF"));
-        this->infoRect = Rectangle::New(0, 95, 1280, 60, COLOR("#17090980"));
-        this->botRect = Rectangle::New(0, 660, 1280, 60, COLOR("#17090980"));
+        this->topRect = Rectangle::New(0, 0, 1280, 94, COLOR("#222D44FF"));
+        this->infoRect = Rectangle::New(0, 95, 1280, 60, COLOR("#222D4480"));
+        this->botRect = Rectangle::New(0, 660, 1280, 60, COLOR("#222D4480"));
         this->titleImage = Image::New(0, 0, "romfs:/images/logo.png");
         this->appVersionText = TextBlock::New(480, 49, "v" + inst::config::appVersion, 22);
         this->appVersionText->SetColor(COLOR("#FFFFFFFF"));
@@ -28,7 +28,7 @@ namespace inst::ui {
         this->butText->SetColor(COLOR("#FFFFFFFF"));
         this->menu = pu::ui::elm::Menu::New(0, 156, 1280, COLOR("#FFFFFF00"), 84, (506 / 84));
         this->menu->SetOnFocusColor(COLOR("#00000033"));
-        this->menu->SetScrollbarColor(COLOR("#17090980"));
+        this->menu->SetScrollbarColor(COLOR("#222D4480"));
         this->Add(this->topRect);
         this->Add(this->infoRect);
         this->Add(this->botRect);

--- a/source/ui/usbInstPage.cpp
+++ b/source/ui/usbInstPage.cpp
@@ -12,12 +12,12 @@ namespace inst::ui {
     extern MainApplication *mainApp;
 
     usbInstPage::usbInstPage() : Layout::Layout() {
-        this->SetBackgroundColor(COLOR("#670000FF"));
+        this->SetBackgroundColor(COLOR("#343E87FF"));
         if (std::filesystem::exists(inst::config::appDir + "/background.png")) this->SetBackgroundImage(inst::config::appDir + "/background.png");
         else this->SetBackgroundImage("romfs:/images/background.jpg");
-        this->topRect = Rectangle::New(0, 0, 1280, 94, COLOR("#170909FF"));
-        this->infoRect = Rectangle::New(0, 95, 1280, 60, COLOR("#17090980"));
-        this->botRect = Rectangle::New(0, 660, 1280, 60, COLOR("#17090980"));
+        this->topRect = Rectangle::New(0, 0, 1280, 94, COLOR("#222D44FF"));
+        this->infoRect = Rectangle::New(0, 95, 1280, 60, COLOR("#222D4480"));
+        this->botRect = Rectangle::New(0, 660, 1280, 60, COLOR("#222D4480"));
         this->titleImage = Image::New(0, 0, "romfs:/images/logo.png");
         this->appVersionText = TextBlock::New(480, 49, "v" + inst::config::appVersion, 22);
         this->appVersionText->SetColor(COLOR("#FFFFFFFF"));
@@ -27,7 +27,7 @@ namespace inst::ui {
         this->butText->SetColor(COLOR("#FFFFFFFF"));
         this->menu = pu::ui::elm::Menu::New(0, 156, 1280, COLOR("#FFFFFF00"), 84, (506 / 84));
         this->menu->SetOnFocusColor(COLOR("#00000033"));
-        this->menu->SetScrollbarColor(COLOR("#17090980"));
+        this->menu->SetScrollbarColor(COLOR("#222D4480"));
         this->infoImage = Image::New(460, 332, "romfs:/images/icons/usb-connection-waiting.png");
         this->Add(this->topRect);
         this->Add(this->infoRect);


### PR DESCRIPTION
For the sake of consistency, I went ahead and changed some of the Hex colour digits so that they reflected the blue background image and got rid of Awoo's red ones. Here's a preview:
![photo_2020-03-18_21-29-21](https://user-images.githubusercontent.com/62312171/77004620-a8060d80-695f-11ea-9d87-b2a96168b58a.jpg)

On a side note, is this repo going to be actively mantained? After compiling and running the freshly built .nro the homebrew still prompt to a 1.3.2B update, there still isn't the `include/Plutonium` directory and all or almost all files are in CRLF. And, idk why, but the icon isn't written to the .nro, at least as of now.
