### PR TITLE
Use a different source_string when installing from USB HDD

### DIFF
--- a/romfs/lang/de.json
+++ b/romfs/lang/de.json
@@ -4,15 +4,15 @@
             "sd": "Von SD-Karte installieren",
             "net": "Über LAN oder Internet installieren",
             "usb": "Über USB installieren",
-			"hdd": "Install over USB HDD",
+            "hdd": "Install over USB HDD",
             "sig": "Verwalte Signatur-Patches",
             "set": "Einstellungen",
             "exit": "Beenden"
         },
-		"hdd": {
-			"title": "USB HDD",
-			"notfound": "USB HDD is not connected."
-		},
+        "hdd": {
+            "title": "USB HDD",
+            "notfound": "USB HDD is not connected."
+        },
         "net": {
             "title": "Netzwerk Verbindung nicht verfügbar",
             "desc": "Überprüfe ob der Flugzeug-Modus deaktiviert ist und ob du mit einem lokalen Netzwerk verbunden bist"
@@ -74,6 +74,9 @@
             "delete_info_multi": " Dateien erfolgreich installiert! Sollen diese von der SD-Karte gelöscht werden?",
             "delete_desc": "Die originalen Dateien werden nach der Installation nicht mehr benötigt",
             "buttons": "\ue0e0 Datei auswählen    \ue0e3 Alle auswählen    \ue0ef Datei(en) installieren    \ue0e1 Abbrechen"
+        },
+        "hdd": {
+            "source_string": " from USB HDD"
         },
         "usb": {
             "help": {

--- a/romfs/lang/en.json
+++ b/romfs/lang/en.json
@@ -4,15 +4,15 @@
             "sd": "Install from SD card",
             "net": "Install over LAN or internet",
             "usb": "Install over USB",
-			"hdd": "Install over USB HDD",
+            "hdd": "Install over USB HDD",
             "sig": "Manage signature patches",
             "set": "Settings",
             "exit": "Exit"
         },
-		"hdd": {
-			"title": "USB HDD",
-			"notfound": "USB HDD is not connected."
-		},
+        "hdd": {
+            "title": "USB HDD",
+            "notfound": "USB HDD is not connected."
+        },
         "net": {
             "title": "Network connection not available",
             "desc": "Check that airplane mode is disabled and you're connected to a local network."
@@ -74,6 +74,9 @@
             "delete_info_multi": " files installed successfully! Delete them from the SD card?",
             "delete_desc": "The original files aren't needed anymore after they've been installed",
             "buttons": "\ue0e0 Select File    \ue0e3 Select All    \ue0ef Install File(s)    \ue0e2 Help    \ue0e1 Cancel"
+        },
+        "hdd": {
+            "source_string": " from USB HDD"
         },
         "usb": {
             "help": {

--- a/romfs/lang/fr.json
+++ b/romfs/lang/fr.json
@@ -4,15 +4,15 @@
             "sd": "Installer à partir de la carte SD",
             "net": "Installer à partir d'un LAN ou d'internet",
             "usb": "Installer à partir d'un périphèrique USB",
-			"hdd": "Install over USB HDD",
+            "hdd": "Install over USB HDD",
             "sig": "Gérer les patchs de signatures",
             "set": " Paramètres",
             "exit": " Quitter"
         },
-		"hdd": {
-			"title": "USB HDD",
-			"notfound": "USB HDD is not connected."
-		},
+        "hdd": {
+            "title": "USB HDD",
+            "notfound": "USB HDD is not connected."
+        },
         "net": {
             "title": "Connection au réseau impossible",
             "desc": "Vérifiez  que le mode avion est désactivé et que vous êtes connecté à un réseau local."
@@ -74,6 +74,9 @@
             "delete_info_multi": " fichiers installés avec succès ! Les supprimer de la carte SD ?",
             "delete_desc": "Les fichiers originaux ne sont plus nécessaires une fois qu'ils ont été installés.",
             "buttons": "\ue0e0 Sélectionnez un fichier    \ue0e3 Tout sélectionner    \ue0ef Installer un/des fichier(s)    \ue0e2 Aide    \ue0e1 Annuler"
+        },
+        "hdd": {
+            "source_string": " from USB HDD"
         },
         "usb": {
             "help": {

--- a/romfs/lang/it.json
+++ b/romfs/lang/it.json
@@ -4,15 +4,15 @@
             "sd": "Installa dalla SD",
             "net": "Installa via LAN o da internet",
             "usb": "Installa via USB",
-			"hdd": "Install over USB HDD",
+            "hdd": "Installa dall'HDD USB",
             "sig": "Gestisci le SigPatches",
             "set": "Impostazioni",
             "exit": "Esci"
         },
-		"hdd": {
-			"title": "USB HDD",
-			"notfound": "USB HDD is not connected."
-		},
+        "hdd": {
+            "title": "HDD USB",
+            "notfound": "L'HDD USB non è connesso."
+        },
         "net": {
             "title": "Connessione alla rete non disponibile",
             "desc": "Controlla che la modalità aereo sia disattivata e che tu sia connesso ad una rete."
@@ -38,7 +38,7 @@
         "net": {
             "help": {
                 "title": "Aiuto",
-                "desc": "I file possono essere installati via remoto da altri dispositivi utilizzando programmi come\nNS-USBloader in modialità \"Tinfoil\". Per inviare file, apri uno\ndi questi software sul tuo PC o sul tuo smartphone, inserisci\nl'indirizzo IP (mostrato sullo schermo), seleziona i file e poi inviali alla\nconsole! Se il software che usi non ti permette di selezionare file\nspecifici, prova a cambiare l'estensione del file in qualcosa che venga accettato dal software.\nTinleaf Installer non legge l'estensione del file durante l'installazione via internet!\n\nSe proprio non riesci, copia i file nella SD e seleziona\nl'opzione \"Installa dalla SD\" dal menù principale!"
+                "desc": "I file possono essere installati via remoto da altri dispositivi utilizzando programmi come\nNS-USBloader in modalità \"Tinfoil\". Per inviare file, apri uno\ndi questi software sul tuo PC o sul tuo smartphone, inserisci\nl'indirizzo IP (mostrato sullo schermo), seleziona i file e poi inviali alla\nconsole! Se il software che usi non ti permette di selezionare file\nspecifici, prova a cambiare l'estensione del file in qualcosa che venga accettato dal software.\nTinleaf Installer non legge l'estensione del file durante l'installazione via internet!\n\nSe proprio non riesci, copia i file nella SD e seleziona\nl'opzione \"Installa dalla SD\" dal menù principale!"
             },
             "src": {
                 "title": "Da dove vuoi installare?",
@@ -66,14 +66,17 @@
         "sd": {
             "help": {
                 "title": "Aiuto",
-                "desc": "Copia i tuoi file NSP, NSZ, XCI, o XCZ nella SD, cercali e\nseleziona quelli che vuoi installare, poi premi Il tasto Più."
+                "desc": "Copia i tuoi file NSP, NSZ, XCI, o XCZ nella SD, cercali e\nseleziona quelli che vuoi installare, poi premi il tasto Più."
             },
-            "top_info": "Seleziona quali file vuoi installare, poi premi Il tasto Più!",
+            "top_info": "Seleziona quali file vuoi installare, poi premi il tasto Più!",
             "source_string": " dalla SD",
             "delete_info": " installato! Cancellarlo dalla SD?",
             "delete_info_multi": " file installati correttamente! Cancellarli dalla SD?",
             "delete_desc": "I file originali non sono più necessari dopo averli installati",
             "buttons": "\ue0e0 Seleziona File    \ue0e3 Seleziona tutto    \ue0ef Installa i File    \ue0e2 Aiuto    \ue0e1 Annulla"
+        },
+        "hdd": {
+            "source_string": " dall'HDD USB"
         },
         "usb": {
             "help": {
@@ -91,7 +94,7 @@
             "desc0": "Dove dovrebbe ",
             "desc1": " essere installato?",
             "desc00": "Dove dovrebbero essere ",
-            "desc01": " instalalti i file selezionati?",
+            "desc01": " installati i file selezionati?",
             "opt0": "SD",
             "opt1": "Memoria interna"
         },

--- a/romfs/lang/jp.json
+++ b/romfs/lang/jp.json
@@ -4,15 +4,15 @@
             "sd": "SDカードからインストール",
             "net": "LANまたはインターネット経由でインストール",
             "usb": "USB経由でインストール",
-			"hdd": "Install over USB HDD",
+            "hdd": "Install over USB HDD",
             "sig": "署名パッチを管理する",
             "set": "設定",
             "exit": "終了"
         },
-		"hdd": {
-			"title": "USB HDD",
-			"notfound": "USB HDD is not connected."
-		},
+        "hdd": {
+            "title": "USB HDD",
+            "notfound": "USB HDD is not connected."
+        },
         "net": {
             "title": "ネットワーク接続は利用できません",
             "desc": "機内モードが無効になっていて、ローカルネットワークに接続していることを確認してください。"
@@ -74,6 +74,9 @@
             "delete_info_multi": " ファイルが正常にインストールされました！ SDカードから削除しますか？",
             "delete_desc": "元のファイルはインストール後に不要になりました",
             "buttons": "\ue0e0 ファイルを選択    \ue0e3 すべて選択    \ue0ef ファイルをインストール    \ue0e2 ヘルプ    \ue0e1 キャンセル"
+        },
+        "hdd": {
+            "source_string": " from USB HDD"
         },
         "usb": {
             "help": {

--- a/romfs/lang/ru.json
+++ b/romfs/lang/ru.json
@@ -4,15 +4,15 @@
             "sd": "Установка из SD-карты",
             "net": "Установка по сети",
             "usb": "Установка через USB",
-			"hdd": "Install over USB HDD",
+            "hdd": "Install over USB HDD",
             "sig": "Управление sig-patches",
             "set": "Настройки",
             "exit": "Выход"
         },
-		"hdd": {
-			"title": "USB HDD",
-			"notfound": "USB HDD is not connected."
-		},
+        "hdd": {
+            "title": "USB HDD",
+            "notfound": "USB HDD is not connected."
+        },
         "net": {
             "title": "Сетевое подключение недоступно",
             "desc": "Удостоверьтесь что авиарежим отключён и вы подключены к локальной сети."
@@ -74,6 +74,9 @@
             "delete_info_multi": " файлы успешно установлены! Удалить их из SD-карты?",
             "delete_desc": "После того, как файлы установлены, они больше не требуются.",
             "buttons": "\ue0e0 Выбрать файл   \ue0e3 Выбрать всё   \ue0ef Установить файл(ы)   \ue0e2 Помощь   \ue0e1 Отмена "
+        },
+        "hdd": {
+            "source_string": " from USB HDD"
         },
         "usb": {
             "help": {

--- a/source/sdInstall.cpp
+++ b/source/sdInstall.cpp
@@ -67,7 +67,10 @@ namespace nspInstStuff {
         try
         {
             for (titleItr = 0; titleItr < ourTitleList.size(); titleItr++) {
-                inst::ui::instPage::setTopInstInfoText("inst.info_page.top_info0"_lang + inst::util::shortenString(ourTitleList[titleItr].filename().string(), 40, true) + "inst.sd.source_string"_lang);
+                if (ourTitleList[titleItr].string().compare(0, 6, "sdmc:/") == 0)
+                    inst::ui::instPage::setTopInstInfoText("inst.info_page.top_info0"_lang + inst::util::shortenString(ourTitleList[titleItr].filename().string(), 40, true) + "inst.sd.source_string"_lang);
+                else
+                    inst::ui::instPage::setTopInstInfoText("inst.info_page.top_info0"_lang + inst::util::shortenString(ourTitleList[titleItr].filename().string(), 40, true) + "inst.hdd.source_string"_lang);
                 std::unique_ptr<tin::install::Install> installTask;
 
                 if (ourTitleList[titleItr].extension() == ".xci" || ourTitleList[titleItr].extension() == ".xcz") {


### PR DESCRIPTION
Bonus: fix some typo on italian translation

Currently if you try to install from USB HDD it wrote "Installing ... from SD".
This commit changed it in order to write "Installing ... from HDD USB" instead